### PR TITLE
Docker file updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Useage
+# Usage
 
-    docker run -p 8080:8080 -d bluespice/elasticsearch
+    docker run -p 9200:9200 -d bluespice/elasticsearch


### PR DESCRIPTION
bash was missing in previous Dockerfile.
Alpine's "mktemp" is not GNU compatible, this is why elasticsearch need modifications to work with that mktemp. Instead of that I changed whole Dockerfile.